### PR TITLE
Allow unprocessed external links in `img` tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,7 @@
+### next version
+* Improved src checking to allow `<img/>` tags (not `<Image/>` components) to
+  use external paths. They will not be processed (as usual), but they also will
+  not crash the server.
+
 ### 0.0.9
 * Fixed Safari display bug

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 Svelte image is a preprocessor which automates image optimization using [sharp](https://github.com/lovell/sharp).
 
-It parses your `img` tags, optimizes or inlines them and replaces src accordingly.
+It parses your `img` tags, optimizes or inlines them and replaces src accordingly. (External images are not optimized.)
 
 `Image` component enables lazyloading and serving multiple sizes via `srcset`.
 

--- a/dev/src/routes/index.svelte
+++ b/dev/src/routes/index.svelte
@@ -39,8 +39,8 @@
 
   <p class="mb-8">
     If you use the normal img tag, your image will be optimized and if its size
-    is below certain threshold if will be inlined as base64 (like Github logo
-    here).
+    is below certain threshold it will be inlined as base64 &mdash; like the Github logo
+    above. (External images will not be optimized.)
   </p>
   <Image alt="fuji" src="fuji.jpg" />
   <Image alt="doggo" src="animals.jpg" />


### PR DESCRIPTION
>I love the fact that you have put together this package! It is just what I was looking for. My big issue was that I have a mix of external and internal links in the project I am working on, and I didn't want to lose all of the image processing on the internal stuff that was a simple `img` tag link.
>
>I am happy to change any code you are not pleased with.
>
>The contents of the commit message are below:

Why:
By default, all `<img>` tags are processed, and even if the docs clearly
stated that you'd need to turn off `optimizeAll` to use any external
sources in your regular image tags, it would be a shame to not get the
benefits on all the rest of your internal images.

How:
**Add a check for external paths on all images**
This is done simply using a RegExp

**Return an object from `getPathname`**
The previous strategy for preventing image processing was throwing an
error. Since we are now expecting some images to be unprocessable, it is
no longer an error. As such, `getPathname` now always returns an object
with all the information necessary to determine if a path should be
processed further.

**Change error strategy inside `replaceInImg` and `replaceInComponent`**
We are now expecting to catch images that are unprocessable before
attempting to optimize. This means that any strange cases are actually
unforseen errors that we can catch in a new try/catch block inside the
`replaceInImg` function. Since developers will likely be using the Image
component in specific cases, the `replaceInComponent` will log expected
path issues to the console, letting everything else attempt to run as
is.