### PR TITLE
Add feature: preserve nested folder structure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 * Improved src checking to allow `<img/>` tags (not `<Image/>` components) to
   use external paths. They will not be processed (as usual), but they also will
   not crash the server.
+* Added Feature: preserve nested folder structure when generating images
 
 ### 0.0.9
 * Fixed Safari display bug


### PR DESCRIPTION
> Here is another feature I needed 😉

Why:
Previously, attempting to use nested folders with images would result in
`sharp(...).toFile(...)` failure because sharp expects the folder to
already be in place before creating the file. Now images can be nested
inside the `/static/` folder as deeply as desired. The structure will be
recreated in the `/g/` folder.

How:
**Fix incidental bug**
Unrelated: fixed the return statement of `getOutPath()`

**Add a `mkdirp` function**
Sapper supports Node 8 or higher, and the `recursive` option in
`fs.mkdir` was not added until 10.12.0. So we need our own.

**Change `getFileName` to `getRelativePath`**
Instead of getting the basename of the file (assuming it is in the
static folder), we get the relative path using the static folder as a
starting point.

Using the new `mkdirp` function, we can ensure that the nested structure
inside the `/g/` directory exists before each call to `.toFile()`. This
actually removes the need for the `init()` function as well.