### PR TITLE
Batch updates: Changelog, bug fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 - Resizing an image that was smaller than any of the given sizes would fail
 ### Added
+- Feature: Image/img src may now start with a "/" (and they all probably should)
 - Development: tooling to automate releases
 ### Changed
 - Changelog format update.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,76 @@
-### next version
-* Improved src checking to allow `<img/>` tags (not `<Image/>` components) to
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+## [Unreleased]
+### Added
+- Development: tooling to automate releases
+### Changed
+- Changelog format update.
+
+
+
+## 0.0.12 - 2019-08-16
+### Added
+- Feature: Image processing preserves nested folder structure within /static dir
+### Fixed
+- Images or imgs without src will not crash the server.
+
+
+## 0.0.11 - 2019-08-16
+### Fixed
+- Bugfix from previous release.
+
+
+
+## 0.0.10 - 2019-08-16
+### Added
+- Changelog
+### Changed
+- Improved src checking to allow `<img/>` tags (not `<Image/>` components) to
   use external paths. They will not be processed (as usual), but they also will
   not crash the server.
-* Added Feature: preserve nested folder structure when generating images
 
-### 0.0.9
-* Fixed Safari display bug
+
+
+## 0.0.9 - 2019-08-04
+### Fixed
+- Safari display bug
+
+
+
+## 0.0.8 - 2019-07-17
+### Added
+- Calculate ratio for images passed through Image component
+
+
+## 0.0.7 - 2019-07-16
+### Fixed
+- Styling bug
+
+
+
+## 0.0.6 - 2019-07-16
+### Changed
+- Pass options directly to Sharp's `webp` function through `options.webpOptions`
+
+
+
+## 0.0.5 - 2019-07-16
+
+
+
+## 0.0.4 - 2019-07-10
+
+
+
+## 0.0.3 - 2019-07-9
+
+
+
+## 0.0.2 - 2019-07-07
+
+
+
+## 0.0.1 - 2019-07-06

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
+### Fixed
+- Resizing an image that was smaller than any of the given sizes would fail
 ### Added
 - Development: tooling to automate releases
 ### Changed

--- a/index.js
+++ b/index.js
@@ -98,6 +98,8 @@ function getSrc(node) {
   return getProp(node, "src") || [{}];
 }
 
+// Checks beginning of string for double leading slash, or the same preceeded by
+// http or https
 const IS_EXTERNAL = /^(https?:)?\/\//;
 
 function willNotProcess(reason) {
@@ -133,10 +135,13 @@ function getProcessingPathsForNode(node, options) {
   // TODO:
   // resolve imported path
 
-  const fullPath = path.resolve("./static/", value.data);
+  // Removes a leading slash, as long as it is not followed by another slash
+  const removedDomainSlash = value.data.replace(/^\/([^\/])/, "$1");
+
+  const fullPath = path.resolve("./static/", removedDomainSlash);
 
   if (fs.existsSync(fullPath)) {
-    return willProcess(value.data, options);
+    return willProcess(removedDomainSlash, options);
   } else {
     return willNotProcess(`The image file does not exist: ${fullPath}`);
   }

--- a/index.js
+++ b/index.js
@@ -55,7 +55,7 @@ async function getBase64(pathname, inlined = false) {
   let size = 64;
 
   if (inlined) {
-    size = await sharp(pathname).metadata();
+    size = (await sharp(pathname).metadata()).size;
   }
 
   const s = await sharp(pathname)
@@ -170,44 +170,54 @@ function insert(content, value, start, end, offset) {
   };
 }
 
-function resize(options, paths) {
-  return async size => {
-    const { outPath, outUrl, outPathWebp } = paths.getResizePaths(size);
-    const meta = await sharp(paths.inPath).metadata();
+async function createSizes(paths, options) {
+  const smallestSize = options.sizes.sort().slice(0, 1);
+  const meta = await sharp(paths.inPath).metadata();
+  const sizes = smallestSize > meta.width ? [meta.width] : options.sizes;
 
-    if (meta.width < size) return null;
+  return (await Promise.all(
+    sizes.map(size => resize(size, paths, options, meta))
+  )).filter(x => !!x);
+}
 
-    ensureOutDirExists(paths.outDir);
+async function resize(size, paths, options, meta = null) {
+  if (!meta) {
+    meta = await sharp(paths.inPath).metadata();
+  }
+  const { outPath, outUrl, outPathWebp } = paths.getResizePaths(size);
 
-    if (options.webp && !fs.existsSync(outPathWebp)) {
-      await sharp(paths.inPath)
-        .resize({ width: size, withoutEnlargement: true })
-        .webp(options.webpOptions)
-        .toFile(outPathWebp);
-    }
+  if (meta.width < size) return null;
 
-    if (fs.existsSync(outPath)) {
-      return {
-        ...meta,
-        filename: outUrl,
-        size
-      };
-    }
+  ensureOutDirExists(paths.outDir);
 
+  if (options.webp && !fs.existsSync(outPathWebp)) {
+    await sharp(paths.inPath)
+      .resize({ width: size, withoutEnlargement: true })
+      .webp(options.webpOptions)
+      .toFile(outPathWebp);
+  }
+
+  if (fs.existsSync(outPath)) {
     return {
       ...meta,
-      ...(await sharp(paths.inPath)
-        .resize({ width: size, withoutEnlargement: true })
-        .jpeg({
-          quality: options.quality,
-          progressive: false,
-          force: false
-        })
-        .png({ compressionLevel: options.compressionLevel, force: false })
-        .toFile(outPath)),
-      size,
-      filename: outUrl
+      filename: outUrl,
+      size
     };
+  }
+
+  return {
+    ...meta,
+    ...(await sharp(paths.inPath)
+      .resize({ width: size, withoutEnlargement: true })
+      .jpeg({
+        quality: options.quality,
+        progressive: false,
+        force: false
+      })
+      .png({ compressionLevel: options.compressionLevel, force: false })
+      .toFile(outPath)),
+    size,
+    filename: outUrl
   };
 }
 
@@ -262,7 +272,7 @@ async function replaceInComponent(edited, node, options) {
     return { content, offset };
   }
 
-  const sizes = await Promise.all(options.sizes.map(resize(options, paths)));
+  const sizes = await createSizes(paths, options);
 
   const base64 =
     options.placeholder === "blur"

--- a/node-scripts/release.ts
+++ b/node-scripts/release.ts
@@ -1,0 +1,330 @@
+import * as path from "path";
+import * as fs from "fs";
+import * as inquirer from "inquirer";
+import * as runscript from "runscript";
+import * as semver from "semver";
+import * as git from "simple-git/promise";
+
+//
+// Settings
+//
+
+const versionTagPrefix = "v";
+const useBranchingTags = true;
+const releaseFromBranch = "master";
+const remoteName = "origin";
+const localReleaseDate = false; // true for local date, false for utc
+const numNewlinesBetweenReleases = 3;
+
+enum ShellCommands {
+  runRegularTests = "yarn test"
+}
+
+enum BumpType {
+  // edit these to change the text displayed in the console
+  patch = "patch: bugix only",
+  minor = "minor: feature release",
+  major = "major: backwards incompatible changes"
+}
+
+const packageFileLocation = path.join(process.cwd(), "package.json");
+const changelogLocation = path.join(process.cwd(), "CHANGELOG.md");
+const changelogUnreleasedText = "## [Unreleased]";
+
+// END SETTINGS
+
+//
+// ARGV flags
+//
+
+const DEBUG = process.argv.includes("--debug");
+const NO_TAG = process.argv.includes("--no-tag");
+const TAG = !NO_TAG;
+
+// End ARGV flags
+
+function errorUnlessDebug(message: string, additionalDebugInfo?: string) {
+  if (!DEBUG) {
+    throw new Error(message);
+  }
+  console.log("DEBUG MODE: The following error would have stopped execution:");
+  console.error(message);
+  if (additionalDebugInfo) {
+    console.log("Additional information:");
+    console.log(additionalDebugInfo);
+  }
+}
+
+function debugLog(message: string, ...additionalMessages: string[]) {
+  if (DEBUG) console.log(`DEBUG MODE: ${message}`);
+  additionalMessages.forEach(console.log);
+}
+
+debugLog("Running in DEBUG MODE. Nothing will be pushed to origin.");
+
+if (NO_TAG) {
+  errorUnlessDebug("You cannot refrain from tagging unless you are debugging");
+}
+
+interface Versions {
+  continuingVersion: string;
+  currentVersion: string;
+  releaseVersion: string;
+}
+
+const initialQuestions: inquirer.QuestionCollection = [
+  {
+    type: "list",
+    name: "bumpType",
+    message: "What kind of release is this?",
+    choices: [BumpType.patch, BumpType.minor, BumpType.major]
+  },
+  {
+    type: "confirm",
+    name: "abort",
+    when: () => changelogIsInvalid(),
+    message:
+      "Whoa! Looks like the CHANGELOG.md file doesn't have any notes on this release you are attempting. Would you like to quit so you can note a few changes for this release?",
+    default: true
+  }
+];
+
+async function allowUserToPublish() {
+  const {confirmPublish} = await inquirer.prompt([
+    {
+      type: 'list',
+      name: 'waitOnPublish',
+      message: "At this point the repo is in a state where you can publish your changes to NPM. This helper script is still running though, so you should open another terminal to run `npm publish`. Once publishing is complete, come back to this terminal and hit return. Alternatively, you could just checkout the commit I've just created for you at a later time and publish to NPM then.",
+      choices: ["OK"],
+    },
+    {
+      type: 'list',
+      name: 'confirmPublish',
+      message: "Were you able to publish to NPM successfully?",
+      choices: [{name:"No, I'm still working on it.", value: false, checked: true}, {name:"Yes/I'll do it later.", value: true}]
+    }
+  ])
+  return confirmPublish || allowUserToPublish()
+}
+
+async function getAnswersFromUser() {
+  const answers = await inquirer.prompt(initialQuestions);
+  if (answers.abort) {
+    console.log("Aborting so that you can make the changes you need.");
+    process.exit();
+  }
+  const bumpType: BumpType = answers.bumpType;
+
+  return { bumpType };
+}
+
+function getPackageJson(): { version: string } {
+  return JSON.parse(fs.readFileSync(packageFileLocation, "utf8"));
+}
+
+function getVersions(
+  bumpTypeAnswer: BumpType | undefined
+): Versions | undefined {
+  let increment: "patch" | "minor" | "major";
+  switch (bumpTypeAnswer) {
+    case BumpType.patch:
+      increment = "patch";
+      break;
+    case BumpType.minor:
+      increment = "minor";
+      break;
+    case BumpType.major:
+      increment = "major";
+      break;
+    case undefined:
+      return undefined;
+    default:
+      throw new Error(`Unknown bumpTypeAnswer: ${bumpTypeAnswer}`);
+  }
+
+  const currentVersion = getPackageJson().version;
+  const releaseVersion = semver.inc(currentVersion, increment);
+  if (!releaseVersion)
+    throw new Error(
+      `either currentVersion or increment were wrong: currentVersion: ${currentVersion}, increment: ${increment}`
+    );
+  const continuingVersion = semver.inc(releaseVersion, "patch") + "-pre";
+
+  console.log({ currentVersion, releaseVersion, continuingVersion });
+
+  return { currentVersion, releaseVersion, continuingVersion };
+}
+
+async function doTests() {
+  if (DEBUG) {
+    debugLog("Would be testing here.");
+  } else {
+    try {
+      await runscript(ShellCommands.runRegularTests);
+      console.log("\n\n");
+    } catch (e) {
+      console.log(
+        `\n\n\n\nDeploy aborted because tests failed. Be sure that you can run \`${ShellCommands.runRegularTests}\` (or \`npm test\` to develop while testing) without failure.\n`
+      );
+      process.exit();
+    }
+  }
+}
+
+async function checkRepoIsReady() {
+  const ON_DESIGNATED_BRANCH = new RegExp(
+    `branch ${escapeRegExp(releaseFromBranch)}`
+  );
+  const IS_CLEAN = /nothing to commit, working [a-z]+ clean/;
+  const errors: string[] = [];
+  let io: string;
+  try {
+    io = (
+      (await runscript("git status", { stdio: "pipe" })).stdout || ""
+    ).toString();
+  } catch (_e) {
+    throw new Error("Git status check threw an error");
+  }
+
+  if (!io) throw new Error("Git status failed. No output");
+  debugLog("Here is the git status output:", io);
+
+  if (!ON_DESIGNATED_BRANCH.test(io))
+    errors.push(`Not on ${releaseFromBranch} branch.`);
+
+  if (!IS_CLEAN.test(io))
+    errors.push(
+      "Uncommitted changes exist. Commit or stash your changes before publishing a new release."
+    );
+
+  if (errors.length > 0) {
+    const allErrors = errors.join(" ");
+    if (DEBUG) {
+      debugLog(
+        "Would have failed and exited here because we have the following errors:",
+        allErrors
+      );
+    } else {
+      console.log(`Cannot create new commit. ${allErrors}`);
+      process.exit();
+    }
+  }
+}
+
+function bumpPackage(version: string) {
+  const json = getPackageJson();
+  json.version = version;
+  fs.writeFileSync(
+    process.cwd() + "/package.json",
+    JSON.stringify(json, null, 2)
+  );
+}
+
+function escapeRegExp(string: string) {
+  return string.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"); // $& means the whole matched string
+}
+
+function changelogIsInvalid(): boolean {
+  const contents: string = fs.readFileSync(changelogLocation, "utf8");
+  const regexForInvalid = new RegExp(
+    `${escapeRegExp(changelogUnreleasedText)}\\s*## \\[`,
+    "g"
+  );
+  return regexForInvalid.test(contents);
+}
+
+function formatDate(date: Date) {
+  if (localReleaseDate) {
+    return `${date.getFullYear()}-${date.getMonth() + 1}-${date.getDate()}`;
+  } else {
+    return `${date.getUTCFullYear()}-${date.getUTCMonth() +
+      1}-${date.getUTCDate()} UTC`;
+  }
+}
+
+function getNewlines() {
+  return Array.from(new Array(numNewlinesBetweenReleases)).reduce(
+    a => a + "\n",
+    ""
+  );
+}
+
+function updateChangelog(version: string, date: Date) {
+  const newText = `${changelogUnreleasedText}\n${getNewlines()}## ${version} - ${formatDate(
+    date
+  )}`;
+  const regex = new RegExp(`^${escapeRegExp(changelogUnreleasedText)}`, "gm");
+  const contents: string = fs.readFileSync(changelogLocation, "utf8");
+  const newContents: string = contents.replace(regex, newText);
+
+  fs.writeFileSync(changelogLocation, newContents);
+}
+
+async function doRelease(versions: Versions) {
+  const releaseTagName = `${versionTagPrefix}${versions.releaseVersion}`;
+  const continuingTagName = `${versionTagPrefix}${versions.continuingVersion}`;
+  const date = new Date();
+  const currentBranch = (await git().raw([
+    "rev-parse",
+    "--abbrev-ref",
+    "HEAD"
+  ])).trim();
+
+  if (currentBranch !== releaseFromBranch) {
+    errorUnlessDebug(
+      `Not on the ${releaseFromBranch} branch. Aborting release.`
+    );
+  }
+
+  bumpPackage(versions.releaseVersion);
+  updateChangelog(versions.releaseVersion, date);
+
+  await git().commit(`Release ${releaseTagName}`, [
+    packageFileLocation,
+    changelogLocation
+  ]);
+
+  if (TAG) {
+    await git().addTag(releaseTagName);
+  await allowUserToPublish();
+    
+
+    if (useBranchingTags) {
+      await git().reset(["--hard", "HEAD~1"]);
+
+      updateChangelog(versions.releaseVersion, date);
+      await git().add(changelogLocation);
+    }
+  } else {
+  await allowUserToPublish();
+  }
+
+  bumpPackage(versions.continuingVersion);
+  await git().add(packageFileLocation);
+
+  await git().commit(`Bump to ${continuingTagName}`);
+
+  if (DEBUG) {
+    debugLog(
+      `Would be pushing ${releaseFromBranch} and tag to ${remoteName} here.`
+    );
+  } else {
+    console.log(
+      `Pushing ${releaseFromBranch} and tag ${releaseTagName} to ${remoteName}.`
+    );
+    await git().push(remoteName, currentBranch);
+    await git().push(remoteName, releaseTagName);
+  }
+}
+
+(async function runRelease() {
+  const { bumpType } = await getAnswersFromUser();
+  const versions = getVersions(bumpType);
+  if (versions) {
+    await checkRepoIsReady();
+    await doTests();
+    await doRelease(versions);
+  }
+
+  console.log("Done! Release complete!");
+})();

--- a/node-scripts/tsconfig.json
+++ b/node-scripts/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compileOnSave": false,
+  "compilerOptions": {
+    "declaration": false,
+    "moduleResolution": "node",
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "strictNullChecks": true,
+    "target": "es5",
+    "typeRoots": [
+      "../node_modules/@types"
+    ],
+    "lib": [
+      "es2017",
+      "dom"
+    ],
+    "module": "commonjs",
+    "baseUrl": "./"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "module": "dist/index.min.mjs",
   "main": "dist/index.min.js",
   "scripts": {
-    "build": "rollup -c"
+    "build": "rollup -c",
+    "release": "ts-node --project node-scripts/tsconfig.json node-scripts/release.ts"
   },
   "repository": {
     "type": "git",
@@ -37,7 +38,16 @@
     "svgo": "^1.2.2"
   },
   "devDependencies": {
+    "@types/inquirer": "^6.5.0",
+    "@types/node": "^12.7.2",
+    "@types/semver": "^6.0.1",
     "eslint": "^6.0.1",
-    "rollup": "^1.16.6"
+    "inquirer": "^7.0.0",
+    "rollup": "^1.16.6",
+    "runscript": "^1.4.0",
+    "semver": "^6.3.0",
+    "simple-git": "^1.124.0",
+    "ts-node": "^8.3.0",
+    "typescript": "^3.6.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "svelte-image",
-  "version": "0.0.11",
+  "version": "0.0.13-pre",
   "description": "Image processing with sharp for Svelte",
   "svelte": "src/Image.svelte",
   "module": "dist/index.min.mjs",

--- a/yarn.lock
+++ b/yarn.lock
@@ -288,6 +288,19 @@
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.39.tgz#e177e699ee1b8c22d23174caaa7422644389509f"
   integrity sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==
 
+"@types/inquirer@^6.5.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@types/inquirer/-/inquirer-6.5.0.tgz#b83b0bf30b88b8be7246d40e51d32fe9d10e09be"
+  integrity sha512-rjaYQ9b9y/VFGOpqBEXRavc3jh0a+e6evAbI31tMda8VlPaSy0AZJfXsvmIe3wklc7W6C3zCSfleuMXR7NOyXw==
+  dependencies:
+    "@types/through" "*"
+    rxjs "^6.4.0"
+
+"@types/node@*", "@types/node@^12.7.2":
+  version "12.7.2"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.7.2.tgz#c4e63af5e8823ce9cc3f0b34f7b998c2171f0c44"
+  integrity sha512-dyYO+f6ihZEtNPDcWNR1fkoTDf3zAK3lAABDze3mz6POyIercH0lEUawUFXlG8xaQZmm1yEBON/4TsYv/laDYg==
+
 "@types/node@^12.0.10":
   version "12.0.12"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.0.12.tgz#cc791b402360db1eaf7176479072f91ee6c6c7ca"
@@ -297,6 +310,18 @@
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/@types/q/-/q-1.5.2.tgz#690a1475b84f2a884fd07cd797c00f5f31356ea8"
   integrity sha512-ce5d3q03Ex0sy4R14722Rmt6MT07Ua+k4FwDfdcToYJcMKNtRVQvJ6JCAPdAmAnbRb6CsX6aYb9m96NGod9uTw==
+
+"@types/semver@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/@types/semver/-/semver-6.0.1.tgz#a984b405c702fa5a7ec6abc56b37f2ba35ef5af6"
+  integrity sha512-ffCdcrEE5h8DqVxinQjo+2d1q+FV5z7iNtPofw3JsrltSoSVlOGaW0rY8XxtO9XukdTn8TaCGWmk2VFGhI70mg==
+
+"@types/through@*":
+  version "0.0.29"
+  resolved "https://registry.yarnpkg.com/@types/through/-/through-0.0.29.tgz#72943aac922e179339c651fa34a4428a4d722f93"
+  integrity sha512-9a7C5VHh+1BKblaYiq+7Tfc+EOmjMdZaD1MYtkQjSoxgB69tBjW98ry6SKsi4zEIWztLOMRuL87A3bdT/Fc/4w==
+  dependencies:
+    "@types/node" "*"
 
 accepts@~1.3.5, accepts@~1.3.7:
   version "1.3.7"
@@ -330,6 +355,13 @@ ansi-escapes@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-3.2.0.tgz#8780b98ff9dbf5638152d1f1fe5c1d7b4442976b"
   integrity sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==
+
+ansi-escapes@^4.2.1:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-4.2.1.tgz#4dccdb846c3eee10f6d64dea66273eab90c37228"
+  integrity sha512-Cg3ymMAdN10wOk/VYfLV7KCQyv7EDirJ64500sU7n9UlmioEtDuU5Gd+hj73hXSU/ex7tHJSssmyftDdkMLO8Q==
+  dependencies:
+    type-fest "^0.5.2"
 
 ansi-regex@^2.0.0:
   version "2.1.1"
@@ -370,6 +402,11 @@ are-we-there-yet@~1.1.2:
   dependencies:
     delegates "^1.0.0"
     readable-stream "^2.0.6"
+
+arg@^4.1.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/arg/-/arg-4.1.1.tgz#485f8e7c390ce4c5f78257dbea80d4be11feda4c"
+  integrity sha512-SlmP3fEA88MBv0PypnXZ8ZfJhwmDeIE3SP71j37AiXQBXYosPV0x6uISAaHYSlSVhmHOVkomen0tbGk6Anlebw==
 
 argparse@^1.0.7:
   version "1.0.10"
@@ -485,6 +522,11 @@ buffer-fill@^1.0.0:
   resolved "https://registry.yarnpkg.com/buffer-fill/-/buffer-fill-1.0.0.tgz#f8f78b76789888ef39f205cd637f68e702122b2c"
   integrity sha1-+PeLdniYiO858gXNY39o5wISKyw=
 
+buffer-from@^1.0.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef"
+  integrity sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==
+
 buffer@^5.2.0:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.2.1.tgz#dd57fa0f109ac59c602479044dca7b8b3d0b71d6"
@@ -543,6 +585,13 @@ cli-cursor@^2.1.0:
   integrity sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=
   dependencies:
     restore-cursor "^2.0.0"
+
+cli-cursor@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-3.1.0.tgz#264305a7ae490d1d03bf0c9ba7c925d1753af307"
+  integrity sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==
+  dependencies:
+    restore-cursor "^3.1.0"
 
 cli-width@^2.0.0:
   version "2.2.0"
@@ -653,7 +702,7 @@ core-js@^2.5.7, core-js@^2.6.5:
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.9.tgz#6b4b214620c834152e179323727fc19741b084f2"
   integrity sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A==
 
-core-util-is@~1.0.0:
+core-util-is@^1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
   integrity sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=
@@ -727,7 +776,7 @@ csso@^3.5.1:
   dependencies:
     css-tree "1.0.0-alpha.29"
 
-debug@2.6.9:
+debug@2.6.9, debug@^2.6.8:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
@@ -785,6 +834,11 @@ detect-libc@^1.0.3:
   resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
   integrity sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=
 
+diff@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.1.tgz#0c667cb467ebbb5cea7f14f135cc2dba7780a8ff"
+  integrity sha512-s2+XdvhPCOF01LRQBC8hf4vhbVmI2CGS5aZnxLJlT5FtdhPCDFq80q++zK2KlrVorVDdL5BOGZ/VfLrVtYNF+Q==
+
 doctrine@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-3.0.0.tgz#addebead72a6574db783639dc87a121773973961"
@@ -832,6 +886,11 @@ emoji-regex@^7.0.1:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-7.0.3.tgz#933a04052860c85e83c122479c4748a8e4c72156"
   integrity sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==
+
+emoji-regex@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"
+  integrity sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==
 
 encodeurl@~1.0.2:
   version "1.0.2"
@@ -1058,6 +1117,13 @@ figures@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/figures/-/figures-2.0.0.tgz#3ab1a2d2a62c8bfb431a0c94cb797a2fce27c962"
   integrity sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=
+  dependencies:
+    escape-string-regexp "^1.0.5"
+
+figures@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/figures/-/figures-3.0.0.tgz#756275c964646163cc6f9197c7a0295dbfd04de9"
+  integrity sha512-HKri+WoWoUgr83pehn/SIgLOMZ9nAWC6dcGj26RY2R4F50u4+RTUz0RCrUlOV3nKRAICW1UGzyb+kcX2qK1S/g==
   dependencies:
     escape-string-regexp "^1.0.5"
 
@@ -1336,6 +1402,25 @@ inquirer@^6.2.2:
     strip-ansi "^5.1.0"
     through "^2.3.6"
 
+inquirer@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-7.0.0.tgz#9e2b032dde77da1db5db804758b8fea3a970519a"
+  integrity sha512-rSdC7zelHdRQFkWnhsMu2+2SO41mpv2oF2zy4tMhmiLWkcKbOAs87fWAJhVXttKVwhdZvymvnuM95EyEXg2/tQ==
+  dependencies:
+    ansi-escapes "^4.2.1"
+    chalk "^2.4.2"
+    cli-cursor "^3.1.0"
+    cli-width "^2.0.0"
+    external-editor "^3.0.3"
+    figures "^3.0.0"
+    lodash "^4.17.15"
+    mute-stream "0.0.8"
+    run-async "^2.2.0"
+    rxjs "^6.4.0"
+    string-width "^4.1.0"
+    strip-ansi "^5.1.0"
+    through "^2.3.6"
+
 ipaddr.js@1.9.0:
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-1.9.0.tgz#37df74e430a0e47550fe54a2defe30d8acd95f65"
@@ -1350,6 +1435,11 @@ is-callable@^1.1.3, is-callable@^1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.1.4.tgz#1e1adf219e1eeb684d691f9d6a05ff0d30a24d75"
   integrity sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==
+
+is-class-hotfix@~0.0.6:
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/is-class-hotfix/-/is-class-hotfix-0.0.6.tgz#a527d31fb23279281dde5f385c77b5de70a72435"
+  integrity sha512-0n+pzCC6ICtVr/WXnN2f03TK/3BfXY7me4cjCAqT8TYXEl0+JBRoqBo94JJHXcyDSLUeWbNX8Fvy5g5RJdAstQ==
 
 is-date-object@^1.0.1:
   version "1.0.1"
@@ -1372,6 +1462,11 @@ is-fullwidth-code-point@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz#a3b30a5c4f199183167aaab93beefae3ddfb654f"
   integrity sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=
+
+is-fullwidth-code-point@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz#f116f8064fe90b3f7844a38997c0b75051269f1d"
+  integrity sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==
 
 is-function@^1.0.1:
   version "1.0.1"
@@ -1411,6 +1506,15 @@ is-symbol@^1.0.2:
   dependencies:
     has-symbols "^1.0.0"
 
+is-type-of@^1.1.0:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/is-type-of/-/is-type-of-1.2.1.tgz#e263ec3857aceb4f28c47130ec78db09a920f8c5"
+  integrity sha512-uK0kyX9LZYhSDS7H2sVJQJop1UnWPWmo5RvR3q2kFH6AUHYs7sOrVg0b4nyBHw29kRRNFofYN/JbHZDlHiItTA==
+  dependencies:
+    core-util-is "^1.0.2"
+    is-class-hotfix "~0.0.6"
+    isstream "~0.1.2"
+
 isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
@@ -1420,6 +1524,11 @@ isexe@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
   integrity sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=
+
+isstream@~0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
+  integrity sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=
 
 jimp@^0.6.4:
   version "0.6.4"
@@ -1499,6 +1608,16 @@ lodash@^4.17.11:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
   integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
 
+lodash@^4.17.15:
+  version "4.17.15"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
+  integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
+
+make-error@^1.1.1:
+  version "1.3.5"
+  resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.5.tgz#efe4e81f6db28cadd605c70f29c831b58ef776c8"
+  integrity sha512-c3sIjNUow0+8swNwVpqoH4YCShKNFkMaw6oH1mNS2haDZQqkeZFlHS3dhoeEbKKmJB4vXpJucU6oH75aDYeE9g==
+
 mdn-data@~1.1.0:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/mdn-data/-/mdn-data-1.1.4.tgz#50b5d4ffc4575276573c4eedb8780812a8419f01"
@@ -1545,6 +1664,11 @@ mimic-fn@^1.0.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-1.2.0.tgz#820c86a39334640e99516928bd03fca88057d022"
   integrity sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==
+
+mimic-fn@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
+  integrity sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==
 
 mimic-response@^1.0.0:
   version "1.0.1"
@@ -1616,6 +1740,11 @@ mute-stream@0.0.7:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"
   integrity sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=
+
+mute-stream@0.0.8:
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.8.tgz#1630c42b2251ff81e2a283de96a5497ea92e5e0d"
+  integrity sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==
 
 nan@^2.13.2:
   version "2.14.0"
@@ -1763,6 +1892,13 @@ onetime@^2.0.0:
   integrity sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=
   dependencies:
     mimic-fn "^1.0.0"
+
+onetime@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/onetime/-/onetime-5.1.0.tgz#fff0f3c91617fe62bb50189636e99ac8a6df7be5"
+  integrity sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==
+  dependencies:
+    mimic-fn "^2.1.0"
 
 optionator@^0.8.2:
   version "0.8.2"
@@ -2099,6 +2235,14 @@ restore-cursor@^2.0.0:
     onetime "^2.0.0"
     signal-exit "^3.0.2"
 
+restore-cursor@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/restore-cursor/-/restore-cursor-3.1.0.tgz#39f67c54b3a7a58cea5236d95cf0034239631f7e"
+  integrity sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==
+  dependencies:
+    onetime "^5.1.0"
+    signal-exit "^3.0.2"
+
 rimraf@2.6.3:
   version "2.6.3"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.3.tgz#b2d104fe0d8fb27cf9e0a1cda8262dd3833c6cab"
@@ -2121,6 +2265,14 @@ run-async@^2.2.0:
   integrity sha1-A3GrSuC91yDUFm19/aZP96RFpsA=
   dependencies:
     is-promise "^2.1.0"
+
+runscript@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/runscript/-/runscript-1.4.0.tgz#14bf5fd3fbd3f31e80c044ef775e7207506cf583"
+  integrity sha512-+RU0jkiJiD0Z51GlnUxl0mCKCpV83WA4y7yNrfZ0A9tH9Go3167KwUqLySjHTvTAHJaEBmgXCG2924ePvZ8nwA==
+  dependencies:
+    debug "^2.6.8"
+    is-type-of "^1.1.0"
 
 rxjs@^6.4.0:
   version "6.5.2"
@@ -2158,6 +2310,11 @@ semver@^6.0.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.2.0.tgz#4d813d9590aaf8a9192693d6c85b9344de5901db"
   integrity sha512-jdFC1VdUGT/2Scgbimf7FSx9iJLXoqfglSF+gJeuNWVpiE37OIbc1jywR/GJyFdz3mnkz2/id0L0J/cr0izR5A==
+
+semver@^6.3.0:
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
+  integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
 
 send@0.17.1:
   version "0.17.1"
@@ -2254,6 +2411,13 @@ simple-get@^3.0.3:
     once "^1.3.1"
     simple-concat "^1.0.0"
 
+simple-git@^1.124.0:
+  version "1.124.0"
+  resolved "https://registry.yarnpkg.com/simple-git/-/simple-git-1.124.0.tgz#10a73cc1af303832b5c11720d4256e134fba35ca"
+  integrity sha512-ks9mBoO4ODQy/xGLC8Cc+YDvj/hho/IKgPhi6h5LI/sA+YUdHc3v0DEoHzM29VmulubpGCxMJUSFmyXNsjNMEA==
+  dependencies:
+    debug "^4.0.1"
+
 simple-swizzle@^0.2.2:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/simple-swizzle/-/simple-swizzle-0.2.2.tgz#a4da6b635ffcccca33f70d17cb92592de95e557a"
@@ -2293,12 +2457,20 @@ smelte@^0.0.8:
     tailwindcss-elevation "^0.3.0"
     tinycolor2 "^1.4.1"
 
+source-map-support@^0.5.6:
+  version "0.5.13"
+  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.13.tgz#31b24a9c2e73c2de85066c0feb7d44767ed52932"
+  integrity sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==
+  dependencies:
+    buffer-from "^1.0.0"
+    source-map "^0.6.0"
+
 source-map@^0.5.3:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
   integrity sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=
 
-source-map@^0.6.1:
+source-map@^0.6.0, source-map@^0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
@@ -2344,6 +2516,15 @@ string-width@^3.0.0:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^5.1.0"
 
+string-width@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.1.0.tgz#ba846d1daa97c3c596155308063e075ed1c99aff"
+  integrity sha512-NrX+1dVVh+6Y9dnQ19pR0pP4FiEIlUvdTGn8pw6CKTNq5sgib2nIhmUNT5TAmhWmvKr3WcxBcP3E8nWezuipuQ==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^5.2.0"
+
 string.prototype.trim@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/string.prototype.trim/-/string.prototype.trim-1.1.2.tgz#d04de2c89e137f4d7d206f086b5ed2fae6be8cea"
@@ -2374,7 +2555,7 @@ strip-ansi@^4.0.0:
   dependencies:
     ansi-regex "^3.0.0"
 
-strip-ansi@^5.1.0:
+strip-ansi@^5.1.0, strip-ansi@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-5.2.0.tgz#8c9a536feb6afc962bdfa5b104a5091c1ad9c0ae"
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
@@ -2547,6 +2728,17 @@ toidentifier@1.0.0:
   resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.0.tgz#7e1be3470f1e77948bc43d94a3c8f4d7752ba553"
   integrity sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==
 
+ts-node@^8.3.0:
+  version "8.3.0"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-8.3.0.tgz#e4059618411371924a1fb5f3b125915f324efb57"
+  integrity sha512-dyNS/RqyVTDcmNM4NIBAeDMpsAdaQ+ojdf0GOLqE6nwJOgzEkdRNzJywhDfwnuvB10oa6NLVG1rUJQCpRN7qoQ==
+  dependencies:
+    arg "^4.1.0"
+    diff "^4.0.1"
+    make-error "^1.1.1"
+    source-map-support "^0.5.6"
+    yn "^3.0.0"
+
 tslib@^1.9.0:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.10.0.tgz#c3c19f95973fb0a62973fb09d90d961ee43e5c8a"
@@ -2566,6 +2758,11 @@ type-check@~0.3.2:
   dependencies:
     prelude-ls "~1.1.2"
 
+type-fest@^0.5.2:
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.5.2.tgz#d6ef42a0356c6cd45f49485c3b6281fc148e48a2"
+  integrity sha512-DWkS49EQKVX//Tbupb9TFa19c7+MK1XmzkrZUR8TAktmE/DizXoaoJV6TZ/tSIPXipqNiRI6CyAe7x69Jb6RSw==
+
 type-is@~1.6.17, type-is@~1.6.18:
   version "1.6.18"
   resolved "https://registry.yarnpkg.com/type-is/-/type-is-1.6.18.tgz#4e552cd05df09467dcbc4ef739de89f2cf37c131"
@@ -2573,6 +2770,11 @@ type-is@~1.6.17, type-is@~1.6.18:
   dependencies:
     media-typer "0.3.0"
     mime-types "~2.1.24"
+
+typescript@^3.6.2:
+  version "3.6.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.6.2.tgz#105b0f1934119dde543ac8eb71af3a91009efe54"
+  integrity sha512-lmQ4L+J6mnu3xweP8+rOrUwzmN+MRAj7TgtJtDaXE5PMyX2kCrklhg3rvOsOIfNeAWMQWO2F1GPc1kMD2vLAfw==
 
 uniq@^1.0.1:
   version "1.0.1"
@@ -2704,3 +2906,8 @@ yallist@^3.0.0, yallist@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.0.3.tgz#b4b049e314be545e3ce802236d6cd22cd91c3de9"
   integrity sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==
+
+yn@^3.0.0:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/yn/-/yn-3.1.1.tgz#1e87401a09d767c1d5eab26a6e4c185182d2eb50"
+  integrity sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==


### PR DESCRIPTION
This is a batch of the commits reproduced below. The first two commits are very opinionated and I don't expect you to just take them without some discussion. I am happy to make changes there, of course.

The first two commits update the changeling/version number and then add tooling to make this easier and more standardized. The formatting of the changelog is totally up to you and the only reason I have changed it is because it fits with some tools that I created a while back to help manage changelogs and tags.

I could configure it differently, but as it stands, it will tag a release, back out that commit, then make a new commit that is continuing along the master branch. If you look at the jQuery repo, you'll see that this is how they do their commits as well.

<img width="611" alt="Screen Shot 2019-09-01 at 1 37 38 AM" src="https://user-images.githubusercontent.com/3663628/64072710-1f40b200-cc59-11e9-8c28-3c9a13f02ab8.png">

You can see in the image above (jQuery's repo) that they will do some work on master, then when they cut a release, it is tagged, but that commit is backed out and a new commit is placed on master which is a continuing version number. So technically the master branch never contains a release that is published to nom, but all those published tags are branched directly off master.

As I mentioned before, this is totally a matter of taste and I am happy to yank any code you don't like.

Which brings me to my next point: I have written that helper script in Typescript. I am again, happy to remove that and convert to plain JS if you like, but I am a fan of TS and thought that if you weren't against the idea, then that would be fine.

I am happy to continue this conversation here or in discord.

Regarding the last two commits: the first fixes a legitimate bug and the second allows people to use the leading slash in their image paths to correctly describe the path to their images on the server.

I have those commits on separate branches as well if you'd rather not pull in the change log stuff, but get the bug fix and the enhancement first. Up to you.

The next thing I will tackle after this is getting the `dev` folder to be an actual testing ground for the package using cypress.

----------

### Catch up changelog & version number

The version number and changelog were a bit out of sync with actual
releases on NPM.

Here, I have updated the version to the _next_ smallest possible version
and appended the `-pre` identifier to signify that this is a prerelease
state of the codebase. At the time of a new release the actual bump size
will be determined and that can be published to NPM.

I have also updated the formatting on the changelog.

### Add Changelog tooling

Why:
This should make the process of updating version numbers and changelog
entries easier and less error prone.

How:
This is a bit of code I have worked on in the past, with a couple
refinements for this repo. When you run `yarn release`, the script will
take over and help you to tag a release with a proper, new version
number.

First, it prompts you to choose a release type: patch, minor, or major.

Next, it updates the changelog and package.json with the release date
and new version number. It creates a commit with these changes and tags
it.

Then, it waits while you publish to NPM in a separate terminal. Once you
have indicated you are done, it will create a new commit with a
continuing version number placeholder in package.json.

Finally, it will push your two new commits and your new tag up to your
origin repo.

### Fix resizing bug

How:
**Remove null sizes from sizes array in `replaceInComponent`**
I've moved the entire loop of resizing out of the calling function and
filtered all null values in a new function called `createSizes`. (Null
values are produced when the original image is smaller than the desired
resized image.)

**Pass original size to `resize` if smallest size is bigger than image**
If an image referenced by the Image component was smaller than the
smallest image size found in user-created options, then no images would
be created. If this is the case, we just pass in the original image's
size.

### Add feature: allow initial slash for images

Why:
All images that can be used inside the application will have to be
resolved from the static directory. As such, the proper way to resolve
those images inside HTML would actually be from the root of the site,
found at "/".

How:
Remove a single leading slash from the front of any image if it is an
internal image.