### PR TITLE
Robustness improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Image accepts following configuration object:
 
 ```
 const defaults = {
+  extensions: ['jpg', 'jpeg', 'png'] // case insensitive. Only jpegs and pngs are currently supported. Others _may_ work by chance.
   optimizeAll: true, // optimize all images discovered in img tags
   inlineBelow: 10000, // inline all images in img tags below 10kb
   compressionLevel: 8, // png quality level

--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ const util = require("util");
 const fs = require("fs");
 
 const defaults = {
+  extensions: ["jpg", "jpeg", "png"],
   optimizeAll: true,
   inlineBelow: 10000,
   compressionLevel: 8,
@@ -103,6 +104,17 @@ function getSrc(node) {
 // http or https
 const IS_EXTERNAL = /^(https?:)?\/\//i;
 
+function fileHasCorrectExtension(filename, options) {
+  return options.extensions
+    .map(x => x.toLowerCase())
+    .includes(
+      filename
+        .split(".")
+        .pop()
+        .toLowerCase()
+    );
+}
+
 function willNotProcess(reason) {
   return {
     willNotProcess: true,
@@ -131,6 +143,11 @@ function getProcessingPathsForNode(node, options) {
   }
   if (IS_EXTERNAL.test(value.data)) {
     return willNotProcess(`The \`src\` is external: ${value.data}`);
+  }
+  if (!fileHasCorrectExtension(value.data, options)) {
+    return willNotProcess(
+      `The file extension is not one of ${options.extensions.join(", ")}.`
+    );
   }
 
   // TODO:

--- a/index.js
+++ b/index.js
@@ -101,7 +101,7 @@ function getSrc(node) {
 
 // Checks beginning of string for double leading slash, or the same preceeded by
 // http or https
-const IS_EXTERNAL = /^(https?:)?\/\//;
+const IS_EXTERNAL = /^(https?:)?\/\//i;
 
 function willNotProcess(reason) {
   return {


### PR DESCRIPTION
A couple quick improvements that I noticed were probably good to push upstream.

### Change external check to be case insensitive

Just for robustness.
### Check file extension

Why:
We were accidentally trying to process anything that was put in an
`<img/>` tag. This won't work for things like SVGs.

How:
Add a simple check for the file extension. Allow the user to override
which files are processed.
