### PR TITLE
Fix inlining bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
-
+### Fixed
+- Bug where inlining on `<img>` failed and caused missing assets.
 
 
 ## 0.1.4 - 2019-11-1 UTC

--- a/src/main.js
+++ b/src/main.js
@@ -345,7 +345,6 @@ async function replaceInComponent(edited, node, options) {
     console.error(reason);
     return { content, offset };
   }
-
   const sizes = await createSizes(paths, options);
 
   const base64 =
@@ -412,8 +411,8 @@ async function replaceInImg(edited, node, options) {
   const [{ start, end }] = getSrc(node);
 
   try {
-    await optimize(paths, options);
-    return insert(content, paths.outUrl, start, end, offset);
+    const outUri = await optimize(paths, options);
+    return insert(content, outUri, start, end, offset);
   } catch (e) {
     return { content, offset };
   }
@@ -447,7 +446,6 @@ async function replaceImages(content, options) {
     content,
     offset: 0
   };
-
   const processed = await imageNodes.reduce(async (edited, node) => {
     if (node.name === "img") {
       return replaceInImg(edited, node, options);


### PR DESCRIPTION
In cases where the inliner should have taken over, the src was changed,
but the file was not created, which caused a missing asset at runtime.