### PR TITLE
Should only walk Element nodes

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -427,7 +427,7 @@ async function replaceImages(content, options) {
   let ast;
   const imageNodes = [];
 
-  if (!content.includes("img") && !content.includes("Image")) return content;
+  if (!content.includes("<img") && !content.includes("<Image")) return content;
 
   try {
     ast = svelte.parse(content);
@@ -435,6 +435,7 @@ async function replaceImages(content, options) {
 
   svelte.walk(ast, {
     enter: node => {
+      if (node.type!=='Element') return;
       if (options.optimizeAll && node.name === "img") {
         imageNodes.push(node);
         return;


### PR DESCRIPTION
When you have any `img` or `Image` word in source it will add it to the list of images to process and then it will warn about it
`The 'src' is blank `

Fixes #33