### PR TITLE
Remove `\n` from srcset

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -334,7 +334,7 @@ function getSrcset(sizes, options, lineFn = srcsetLine, tag = "srcset") {
   const srcSetValue = s
     .filter(f => f)
     .map(lineFn(options))
-    .join(",\n");
+    .join();
 
   return ` ${tag}=\'${srcSetValue}\' `;
 }


### PR DESCRIPTION
When exporting with sapper, srcset get's an unwanted `\g`
```html
<source srcset="g/images/homepage-400.webp 375w,\ng/images/homepage-800.webp 768w,\ng/images/homepage-1200.webp 1024w" type=image/webp> 
```
So it will get a 404 and fallback to the default image.

`.join()` by default , adds the needed `,`