### PR TITLE
Send correct parameters to resize

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -295,7 +295,7 @@ async function createSizes(paths) {
   const sizes = smallestSize > meta.width ? [meta.width] : options.sizes;
 
   return (
-    await Promise.all(sizes.map(size => resize(size, paths, options, meta)))
+    await Promise.all(sizes.map(size => resize(size, paths, meta)))
   ).filter(Boolean);
 }
 


### PR DESCRIPTION
I was running into problems and found that we aren't passing the correct parameters to the `resize` call. We're passing `options` as the third parameter and `meta` as the fourth, however, `resize` expects `meta` as the third parameter and uses the module level `options`.

The end result was that when `replaceInComponent` tried to use the returned metadata from `createSizes`, it received the options object back instead, which causes the `1 / (sizes[0].width / sizes[0].height)) * 100` ratio calculation to end up as `ratio='NaN%'` since the width/height properties are undefined. So the div in the `Image` component that uses the ratio as `padding-bottom` had none, and the image was hidden.