### PR TITLE
A couple Windows fixes

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -346,7 +346,7 @@ function mkdirp(dir) {
     if (fs.existsSync(dir)) {
       return dir;
     }
-    return mkdirp(dir.split("/"));
+    return mkdirp(dir.split(path.sep));
   }
 
   return dir.reduce((created, nextPart) => {

--- a/src/main.js
+++ b/src/main.js
@@ -358,11 +358,13 @@ function mkdirp(dir) {
   }, "");
 }
 
+const pathSepPattern = new RegExp('\\' + path.sep, 'g');
+
 const srcsetLine = options => (s, i) =>
-  `${s.filename} ${options.breakpoints[i]}w`;
+  `${s.filename.replace(pathSepPattern, '/')} ${options.breakpoints[i]}w`;
 
 const srcsetLineWebp = options => (s, i) =>
-  `${s.filename} ${options.breakpoints[i]}w`
+  `${s.filename.replace(pathSepPattern, '/')} ${options.breakpoints[i]}w`
     .replace("jpg", "webp")
     .replace("png", "webp")
     .replace("jpeg", "webp");


### PR DESCRIPTION
I needed a couple small fixes for this to work on Windows:
* The mkdirp call would always split with '/' but should use the OS path separator. Fixes #48 
* The srcset url should always use '/' but was using the OS path separator. The browser seemed to figure it out anyway, but it still should be fixed.