### PR TITLE
Fix `tagName` option

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -476,7 +476,7 @@ async function replaceImages(content) {
   let ast;
   const imageNodes = [];
 
-  if (!content.includes("<img") && !content.includes("<Image")) return content;
+  if (!content.includes("<img") && !content.includes(`<${options.tagName}`)) return content;
 
   try {
     ast = svelte.parse(content);


### PR DESCRIPTION
Replaced reference to static "Image" string to `option.tagName`. This allows for custom tagNames to be processed.