### PR TITLE
add offset prop to Waypoint component

### DIFF
--- a/src/Image.svelte
+++ b/src/Image.svelte
@@ -11,6 +11,7 @@
   export let ratio = "100%";
   export let blur = false;
   export let sizes = "(max-width: 1000px) 100vw, 1000px";
+  export let offset = 0;
   export let threshold = 1.0;
   export let lazy = true;
   export let wrapperClass = "";
@@ -67,6 +68,7 @@
   style="min-height: 100px; width: 100%;"
   once
   {threshold}
+  {offset}
   disabled="{!lazy}"
 >
   <div class:loaded style="position: relative; width: 100%;">


### PR DESCRIPTION
Hello @matyunya, thanks for this library. It really help my site performance so much with image lazy loading with compressed images.

However, I've ran into a scenario of using the `svelte-image` component with some animations to be triggered on certain scollY value. I see you already have this offset prop in `svelte-waypoint`.

This will help me to load the image that is below the specific offset height, so that when animation is starting in the viewport image is already loaded.
