### PR TITLE
add slash to README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ And have fun!
   import Image from "svelte-image";
 </script>
 
-<Image src="fuji.jpg">
+<Image src="fuji.jpg" />
 ```
 
 Will generate
@@ -59,7 +59,7 @@ Will generate
 ## Image path
 
 Please note that the library works only with relative paths in Sapper at the moment.
-`<Image src="images/fuji.jpg">` works whereas `<Image src="/images/fuji.jpg">` doesn't.
+`<Image src="images/fuji.jpg" />` works whereas `<Image src="/images/fuji.jpg" />` doesn't.
 
 ### Svelte + Rollup
 


### PR DESCRIPTION
I was getting some very odd errors for a bit because I just copied the demo off of the README page, which had a missing slash at the end of the `<Image />` tag. It used `<Image>` instead, which apparently isn't valid svelte. Maybe this will save some time of future copying idiots like me...