### PR TITLE
Placeholder blur

### DIFF
--- a/src/Image.svelte
+++ b/src/Image.svelte
@@ -88,7 +88,7 @@
       {#if blurhash}
         <canvas class="placeholder" use:decodeBlurhash width={blurhashSize.width} height={blurhashSize.height} />
       {:else}
-        <img class="placeholder {placeholderClass}" {src} {alt} />
+        <img class="placeholder {placeholderClass}" class:blur {src} {alt} />
       {/if}
       <picture>
         <source type="image/webp" srcset="{srcsetWebp}" {sizes} />
@@ -97,7 +97,6 @@
           {src}
           use:load
           class="main {c} {className}"
-          class:blur
           {alt}
           {width}
           {height}

--- a/src/Image.svelte
+++ b/src/Image.svelte
@@ -10,7 +10,7 @@
   export let srcset = "";
   export let srcsetWebp = "";
   export let ratio = "100%";
-  export let blur = false;
+  export let blur = true;
   export let sizes = "(max-width: 1000px) 100vw, 1000px";
   export let offset = 0;
   export let threshold = 1.0;


### PR DESCRIPTION
Moves blur filter from loaded image to placeholder to smooth out its pixelation. 
I might totally misinterpreting the reason it was set up that way originally but feels more useful to change it 😊