### PR TITLE
Add full folder pre-processing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
+### Changed
+- Documented actual behavior of "/" at the start of an image path
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
+### Added
+- Optionally process entire folders of images, regardless of image references in
+  your svelte components
 ### Changed
 - Documented actual behavior of "/" at the start of an image path
-
+- If an image is set to be optimized, but the destination (optimized) file
+  exists, it is skipped
 
 
 ## 0.2.7 - 2020-9-1 UTC

--- a/README.md
+++ b/README.md
@@ -58,8 +58,11 @@ Will generate
 
 ## Image path
 
-Please note that the library works only with relative paths in Sapper at the moment.
-`<Image src="images/fuji.jpg" />` works whereas `<Image src="/images/fuji.jpg" />` doesn't.
+Please note that the library works only with paths from root in Sapper at the moment.
+`<Image src="images/fuji.jpg" />` works the same as `<Image src="/images/fuji.jpg" />`.
+
+In reality, based on how Sapper moves the `static` folder into the root of your project,
+tchnically all image paths should probably start with a `/` to best represent actual paths.
 
 ### Svelte + Rollup
 

--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ export default {
 ## Configuration and defaults
 
 Image accepts following configuration object:
+Inside your rollup config, `image` accepts following configuration object:
 
 ```js
 const defaults = {
@@ -102,7 +103,7 @@ const defaults = {
   // processed by the <img> tag (assuming `optimizeAll` above is true). Empty
   // the array to allow all extensions to be processed. However, only jpegs and
   // pngs are explicitly supported.
-  imgTagExtensions: ['jpg', 'jpeg', 'png'],
+  imgTagExtensions: ["jpg", "jpeg", "png"],
 
   // Same as the above, except that this array applies to the Image Component.
   // If the images passed to your image component are unknown, it might be a
@@ -127,6 +128,7 @@ const defaults = {
   // should be ./static for Sapper and ./public for plain Svelte projects
   publicDir: "./static/",
 
+
   placeholder: "trace", // or "blur",
 
   // WebP options [sharp docs](https://sharp.pixelplumbing.com/en/stable/api-output/#webp)
@@ -143,10 +145,38 @@ const defaults = {
     background: "#fff",
     color: "#002fa7",
     threshold: 120
-  }
 
   // Wheter to download and optimize remote images loaded from a url
   optimizeRemote: true,
+  },
+
+  //
+  // Declared image folder processing
+  //
+  // The options below are only useful if you'd like to process entire folders
+  // of images, regardless of whether or not they appear in any templates in
+  // your application (in addition to all the images that are found at build
+  // time). This is useful if you build dynamic strings to reference images you
+  // know should exist, but that cannot be determined at build time.
+
+  // Relative paths (starting from `/static`) of folders you'd like to process
+  // from top to bottom. This is a recursive operation, so all images that match
+  // the `processFoldersExtensions` array will be processed. For example, an
+  // array ['folder-a', 'folder-b'] will process all images in
+  // `./static/folder-a/` and `./static/folder-b`.
+  processFolders: [],
+
+  // When true, the folders in the options above will have all subfolders
+  // processed recursively as well.
+  processFoldersRecursively: false,
+
+  // Only files with these extensions will ever be processed when invoking
+  // `processFolders` above.
+  processFoldersExtensions: ["jpeg", "jpg", "png"],
+
+  // Add image sizes to this array to create different asset sizes for any image
+  // that is processed using `processFolders`
+  processFoldersSizes: false
 };
 ```
 
@@ -184,6 +214,64 @@ Following props are filled by preprocessor:
 - [x] Support WebP
 - [ ] Optimize background or whatever images found in CSS
 - [ ] Resolve imported images (only works with string pathnames at the moment)
+
+### Optimizing dynamically referenced images
+
+Svelte Image is great at processing all the images that you reference with
+string literals in your templates. When Sapper pre-processes your files, things
+like `<img src="/images/me.jpg">` and `<Image src="/images/you.jpg"/>` tell the
+pre-processor to create optimized versions of the files and rewrite the paths to
+point to the optimized version.
+
+However, we have no way of knowing the value of any dynamic paths at build time.
+
+```
+<img src={path}>
+
+```
+
+The code above is completely useless to our image processor, and so we ignore
+it.
+
+However, there may be times when you are well aware that you will be, for
+example, looping over a set of images that will be rendered in `<img>` tags and
+you would like the sources to be optimized. We can work around the limitation
+above by telling the pre-processor to optimize images in specific folders via
+the `processFolders` array in the config options.
+
+For example, if your config looks something like this
+
+```js
+import image from "svelte-image";
+
+
+svelte({
+  preprocess: {
+    ...image({
+      sizes: [200, 400],
+      processFolders: ['people/images']
+    }),
+  }
+})
+```
+
+Then, assuming you have the `people/images` folder populated inside your
+`static` folder, you can dynamically build strings that target optimized images
+like this:
+
+```svelte
+<script>
+  const images = ["lisa", "bart"]
+    .map(person => `/g/people/images/${person}-200.jpg`)
+</script>
+
+{#each images as personImage}
+  <img src={personImage}>
+{/each}
+```
+
+We will ignore your `<img>` at build time, but because we processed the entire
+`people/images` folder anyway, the images will be available to call at run time.
 
 ## Development
 

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -70,6 +70,301 @@ describe("extension filtering", () => {
   });
 });
 
+describe("folder image processing", () => {
+  test("it creates assets for all images", async () => {
+    populateFiles({
+      "images/1.jpg": "1.jpg",
+      "images/2.jpg": "1.jpg",
+      "images/3.png": "4.png"
+    });
+
+    const replaceImages = getReplaceImages({
+      processFolders: ["images"],
+      processFoldersExtensions: ["jpg", "png"]
+    });
+
+    await replaceImages(`no tag necessary`);
+
+    expect(fs.existsSync("./static/g/images/1.jpg")).toBeTruthy();
+    expect(fs.existsSync("./static/g/images/2.jpg")).toBeTruthy();
+    expect(fs.existsSync("./static/g/images/3.png")).toBeTruthy();
+  });
+
+  test("by default, it creates assets non-recursively", async () => {
+    populateFiles({
+      "images/1.jpg": "1.jpg",
+      "images/2.jpg": "1.jpg",
+      "images/3.png": "4.png",
+      "images/subfolder/1.jpg": "1.jpg",
+      "images/subfolder/2.jpg": "1.jpg"
+    });
+
+    const replaceImages = getReplaceImages({
+      processFolders: ["images"],
+      processFoldersExtensions: ["jpg", "png"]
+    });
+
+    await replaceImages(`no tag necessary`);
+
+    expect(fs.existsSync("./static/g/images/1.jpg")).toBeTruthy();
+    expect(fs.existsSync("./static/g/images/2.jpg")).toBeTruthy();
+    expect(fs.existsSync("./static/g/images/3.png")).toBeTruthy();
+    expect(fs.existsSync("./static/g/images/subfolder/1.jpg")).not.toBeTruthy();
+    expect(fs.existsSync("./static/g/images/subfolder/2.jpg")).not.toBeTruthy();
+  });
+
+  test("optionally, it creates assets recursively", async () => {
+    populateFiles({
+      "recurse/1.jpg": "1.jpg",
+      "recurse/2.jpg": "1.jpg",
+      "recurse/3.png": "4.png",
+      "recurse/subfolder/1.jpg": "1.jpg",
+      "recurse/subfolder/2.jpg": "1.jpg"
+    });
+
+    const replaceImages = getReplaceImages({
+      processFolders: ["recurse"],
+      processFoldersExtensions: ["jpg", "png"],
+      processFoldersRecursively: true
+    });
+
+    await replaceImages(`no tag necessary`);
+
+    expect(fs.existsSync("./static/g/recurse/1.jpg")).toBeTruthy();
+    expect(fs.existsSync("./static/g/recurse/2.jpg")).toBeTruthy();
+    expect(fs.existsSync("./static/g/recurse/3.png")).toBeTruthy();
+    expect(fs.existsSync("./static/g/recurse/subfolder/1.jpg")).toBeTruthy();
+    expect(fs.existsSync("./static/g/recurse/subfolder/2.jpg")).toBeTruthy();
+  });
+
+  test("optionally, it creates asset sizes as well", async () => {
+    populateFiles({
+      "recurse/1.jpg": "1.jpg",
+      "recurse/2.jpg": "1.jpg",
+      "recurse/3.png": "4.png",
+      "recurse/subfolder/1.jpg": "1.jpg",
+      "recurse/subfolder/2.jpg": "1.jpg"
+    });
+
+    const replaceImages = getReplaceImages({
+      sizes: [100, 200],
+      processFolders: ["recurse"],
+      processFoldersExtensions: ["jpg", "png"],
+      processFoldersRecursively: true,
+      processFoldersSizes: true
+    });
+
+    await replaceImages(`no tag necessary`);
+
+    expect(fs.existsSync("./static/g/recurse/1-100.jpg")).toBeTruthy();
+    expect(fs.existsSync("./static/g/recurse/1-200.jpg")).toBeTruthy();
+    expect(fs.existsSync("./static/g/recurse/2-100.jpg")).toBeTruthy();
+    expect(fs.existsSync("./static/g/recurse/2-200.jpg")).toBeTruthy();
+    expect(fs.existsSync("./static/g/recurse/3-100.png")).toBeTruthy();
+    expect(fs.existsSync("./static/g/recurse/3-200.png")).toBeTruthy();
+    expect(
+      fs.existsSync("./static/g/recurse/subfolder/1-100.jpg")
+    ).toBeTruthy();
+    expect(
+      fs.existsSync("./static/g/recurse/subfolder/1-200.jpg")
+    ).toBeTruthy();
+    expect(
+      fs.existsSync("./static/g/recurse/subfolder/2-100.jpg")
+    ).toBeTruthy();
+    expect(
+      fs.existsSync("./static/g/recurse/subfolder/2-200.jpg")
+    ).toBeTruthy();
+  });
+
+  test("it skips sizes already created", async () => {
+    populateFiles({
+      "images/1.jpg": "1.jpg",
+      "images/2.jpg": "1.jpg",
+      "images/3.png": "4.png"
+    });
+
+    // Make empty files at the expected locations of resized files
+    fs.mkdirSync("./static/g/images", { recursive: true });
+    fs.closeSync(fs.openSync("./static/g/images/1-100.jpg", "w"));
+    fs.closeSync(fs.openSync("./static/g/images/2-100.jpg", "w"));
+    fs.closeSync(fs.openSync("./static/g/images/3-100.png", "w"));
+
+    const replaceImages = getReplaceImages({
+      sizes: [100],
+      processFolders: ["images"],
+      processFoldersExtensions: ["jpg", "png"],
+      processFoldersSizes: true
+    });
+
+    await replaceImages(`no tag necessary`);
+
+    expect(fs.statSync("./static/g/images/1-100.jpg").size).toBe(0);
+    expect(fs.statSync("./static/g/images/2-100.jpg").size).toBe(0);
+    expect(fs.statSync("./static/g/images/3-100.png").size).toBe(0);
+  });
+
+  test("by default, it does not create asset sizes as well", async () => {
+    populateFiles({
+      "recurse/1.jpg": "1.jpg",
+      "recurse/2.jpg": "1.jpg",
+      "recurse/3.png": "4.png",
+      "recurse/subfolder/1.jpg": "1.jpg",
+      "recurse/subfolder/2.jpg": "1.jpg"
+    });
+
+    const replaceImages = getReplaceImages({
+      sizes: [100, 200],
+      processFolders: ["recurse"],
+      processFoldersExtensions: ["jpg", "png"],
+      processFoldersRecursively: true
+    });
+
+    await replaceImages(`no tag necessary`);
+
+    expect(fs.existsSync("./static/g/recurse/1-100.jpg")).not.toBeTruthy();
+    expect(fs.existsSync("./static/g/recurse/1-200.jpg")).not.toBeTruthy();
+    expect(fs.existsSync("./static/g/recurse/2-100.jpg")).not.toBeTruthy();
+    expect(fs.existsSync("./static/g/recurse/2-200.jpg")).not.toBeTruthy();
+    expect(fs.existsSync("./static/g/recurse/3-100.png")).not.toBeTruthy();
+    expect(fs.existsSync("./static/g/recurse/3-200.png")).not.toBeTruthy();
+    expect(
+      fs.existsSync("./static/g/recurse/subfolder/1-100.jpg")
+    ).not.toBeTruthy();
+    expect(
+      fs.existsSync("./static/g/recurse/subfolder/1-200.jpg")
+    ).not.toBeTruthy();
+    expect(
+      fs.existsSync("./static/g/recurse/subfolder/2-100.jpg")
+    ).not.toBeTruthy();
+    expect(
+      fs.existsSync("./static/g/recurse/subfolder/2-200.jpg")
+    ).not.toBeTruthy();
+  });
+
+  test("it only runs on the first component parse", async () => {
+    populateFiles({
+      "recurse/1.jpg": "1.jpg"
+    });
+
+    const replaceImages = getReplaceImages({
+      processFolders: ["recurse"],
+      processFoldersExtensions: ["jpg"]
+    });
+
+    await replaceImages(`no tag necessary`);
+    expect(fs.existsSync("./static/g/recurse/1.jpg")).toBeTruthy();
+
+    await cleanFiles();
+    populateFiles({
+      "recurse/1.jpg": "1.jpg"
+    });
+
+    expect(fs.existsSync("./static/g/recurse/1.jpg")).not.toBeTruthy();
+
+    await replaceImages(`again, no tag`);
+    expect(fs.existsSync("./static/g/recurse/1.jpg")).not.toBeTruthy();
+  });
+
+  test("it ignores the inline option", async () => {
+    // We need to assume that the user wants all images, even if they fall below
+    // the normal inlining limit.
+
+    populateFiles({
+      "recurse/1.jpg": "1.jpg"
+    });
+
+    const replaceImages = getReplaceImages({
+      processFolders: ["recurse"],
+      processFoldersExtensions: ["jpg"],
+      inlineBelow: Infinity
+    });
+
+    await replaceImages(`no tag necessary`);
+    expect(fs.existsSync("./static/g/recurse/1.jpg")).toBeTruthy();
+  });
+
+  test("it skips images already created", async () => {
+    populateFiles({
+      "images/1.jpg": "1.jpg",
+      "images/2.jpg": "1.jpg",
+      "images/3.png": "4.png"
+    });
+
+    // Make empty files at the expected locations of resized files
+    fs.mkdirSync("./static/g/images", { recursive: true });
+    fs.closeSync(fs.openSync("./static/g/images/1.jpg", "w"));
+    fs.closeSync(fs.openSync("./static/g/images/2.jpg", "w"));
+    fs.closeSync(fs.openSync("./static/g/images/3.png", "w"));
+
+    const replaceImages = getReplaceImages({
+      processFolders: ["images"],
+      processFoldersExtensions: ["jpg", "png"]
+    });
+
+    await replaceImages(`no tag necessary`);
+
+    expect(fs.statSync("./static/g/images/1.jpg").size).toBe(0);
+    expect(fs.statSync("./static/g/images/2.jpg").size).toBe(0);
+    expect(fs.statSync("./static/g/images/3.png").size).toBe(0);
+  });
+
+  test("does not process other folders", async () => {
+    populateFiles({
+      "recurse/1.jpg": "1.jpg",
+      "recurse/2.jpg": "1.jpg",
+      "recurse/3.png": "4.png",
+      "recurse/subfolder/1.jpg": "1.jpg",
+      "recurse/subfolder/2.jpg": "1.jpg",
+      "noRecurse/1.jpg": "1.jpg",
+      "noRecurse/2.jpg": "1.jpg",
+      "noRecurse/subfolder/1.jpg": "1.jpg",
+      "noRecurse/subfolder/2.jpg": "1.jpg"
+    });
+
+    const replaceImages = getReplaceImages({
+      processFolders: ["recurse"],
+      processFoldersExtensions: ["jpg", "png"]
+    });
+
+    await replaceImages(`no tag necessary`);
+
+    expect(fs.existsSync("./static/g/noRecurse/1.jpg")).not.toBeTruthy();
+    expect(fs.existsSync("./static/g/noRecurse/2.jpg")).not.toBeTruthy();
+    expect(
+      fs.existsSync("./static/g/noRecurse/subfolder/1.jpg")
+    ).not.toBeTruthy();
+    expect(
+      fs.existsSync("./static/g/noRecurse/subfolder/2.jpg")
+    ).not.toBeTruthy();
+  });
+
+  test("it skips images that are not in the extensions list", async () => {
+    populateFiles({
+      "recurse/1.jpg": "1.jpg",
+      "recurse/2.jpg": "1.jpg",
+      "recurse/3.png": "4.png",
+      "recurse/subfolder/1.jpg": "1.jpg",
+      "recurse/subfolder/2.png": "4.png"
+    });
+
+    const replaceImages = getReplaceImages({
+      processFolders: ["recurse"],
+      processFoldersExtensions: ["jpg"],
+      processFoldersRecursively: true
+    });
+
+    await replaceImages(`no tag necessary`);
+
+    expect(fs.existsSync("./static/g/recurse/1.jpg")).toBeTruthy();
+    expect(fs.existsSync("./static/g/recurse/2.jpg")).toBeTruthy();
+    expect(fs.existsSync("./static/g/recurse/3.png")).not.toBeTruthy();
+    expect(fs.existsSync("./static/g/recurse/subfolder/1.jpg")).toBeTruthy();
+    expect(
+      fs.existsSync("./static/g/recurse/subfolder/2.png")
+    ).not.toBeTruthy();
+  });
+});
+
 describe("inlining images in <img> tags", () => {
   test("works below threshold", async () => {
     populateFiles({

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -1,7 +1,8 @@
-const fs = require('fs')
-const path = require('path')
+const fs = require("fs");
+const path = require("path");
 const targetFolder = path.join(process.cwd(), "static");
-const getPreprocessor = require('../src/index')
+const getPreprocessor = require("../src/index");
+const { defaults } = require("../src/main")
 
 /**
  * Test helper to populate files into the expected directory and will use files
@@ -54,10 +55,13 @@ function cleanFiles() {
  * Convenience function to get directly at the main thing we will be testing
  * @param {*} options Same as the options you'd pass to getPreprocessor
  */
-const getReplaceImages = (options) => (str) => getPreprocessor(options).markup({content:str}).then((obj) => obj.code)
+function getReplaceImages(options) {
+  const preprocessor = getPreprocessor({...defaults, ...options});
+  return str => preprocessor.markup({ content: str }).then(obj => obj.code);
+}
 
 module.exports = {
   cleanFiles,
   populateFiles,
   getReplaceImages
-}
+};


### PR DESCRIPTION
This feature has been extremely useful to me for my project. I've been using it for quite some time with no issue, and figured that this would be a good time to PR it into the main repo: before the switch to compatibility with SvelteKit.

Essentially, you give options for a folder whose images should all be processed before the fact, and they will all get done in one fell swoop. This is also a great workaround for dynamic image references (#31). They can still be optimized ahead of time!