### PR TITLE
Pass usemap attribute to underlying img

### DIFF
--- a/src/Image.svelte
+++ b/src/Image.svelte
@@ -6,6 +6,7 @@
   export let alt = "";
   export let width = null;
   export let height = null;
+  export let usemap = "";
   export let src = "";
   export let srcset = "";
   export let srcsetWebp = "";
@@ -102,6 +103,7 @@
           {alt}
           {width}
           {height}
+          {usemap}
         />
       </picture>
     </div>


### PR DESCRIPTION
This PR allows passing a `usemap` attribute (used for image maps) to the `Image` component which is then subsequently passed to the `img` element.