### PR TITLE
Fix/process once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
+
+
+## 0.2.9 - 2020-12-16 UTC
 ### Added
 - Optionally process entire folders of images, regardless of image references in
   your svelte components

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   times, even with the same options.
 - Bug where we would always download an external image, even if we had already
   done so.
+- Bug where options were not reset to defaults bewtween calls to
+  `getPreprocessor`
 
 
 ## 0.2.9 - 2020-12-16 UTC

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Bug where we would attempt to re-process folders when using
   `processImageFolders` if the main export from this package was called multiple
   times, even with the same options.
+- Bug where we would always download an external image, even if we had already
+  done so.
 
 
 ## 0.2.9 - 2020-12-16 UTC

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
+### Fixed
+- Bug where we would attempt to re-process folders when using
+  `processImageFolders` if the main export from this package was called multiple
+  times, even with the same options.
 
 
 ## 0.2.9 - 2020-12-16 UTC

--- a/src/main.js
+++ b/src/main.js
@@ -643,6 +643,7 @@ function processFolders() {
     .finally(() => (options.inlineBelow = inlineBelow));
 }
 
+let processFoldersRunIds = [];
 /**
  * @param {Partial<typeof options>} opts
  */
@@ -652,10 +653,22 @@ function getPreprocessor(opts = {}) {
     ...opts
   };
 
-  let ran = false;
   async function processFoldersOnce() {
-    if (ran) return;
-    ran = true;
+    const {
+      processFolders: foldersToProcess,
+      processFoldersExtensions,
+      processFoldersRecursively,
+      processFoldersSizes
+    } = options
+    const runId = JSON.stringify({
+      processFolders: foldersToProcess,
+      processFoldersExtensions,
+      processFoldersRecursively,
+      processFoldersSizes
+    })
+    
+    if (processFoldersRunIds.includes(runId)) return;
+    processFoldersRunIds.push(runId);
 
     await processFolders();
   }

--- a/src/main.js
+++ b/src/main.js
@@ -649,7 +649,7 @@ let processFoldersRunIds = [];
  */
 function getPreprocessor(opts = {}) {
   options = {
-    ...options,
+    ...JSON.parse(JSON.stringify(defaults)),
     ...opts
   };
 

--- a/src/main.js
+++ b/src/main.js
@@ -110,7 +110,7 @@ async function downloadImage(url, folder = ".") {
   const filename = `${hash}.${ext}`;
   const saveTo = path.resolve(folder, filename);
 
-  if (fs.existsSync(path)) return filename;
+  if (fs.existsSync(saveTo)) return filename;
 
   const writer = fs.createWriteStream(saveTo);
   const response = await axios({


### PR DESCRIPTION
A changelog update, then three issues.

1. Fix logic that determines if we should run `processFolders` again.
2. Fix `downloadImage` function: there is a bug that forces us to *always* download an image.
3. Fix options creep. Multiple calls to `getPreprocessor` continually mutate options (fine), but they are never reset to the defaults (whoops).