### PR TITLE
Bump blurhash for SvelteKit support

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "homepage": "https://github.com/matyunya/svelte-image#readme",
   "dependencies": {
     "axios": "^0.21.1",
-    "blurhash": "^1.1.3",
+    "blurhash": "^1.1.4",
     "potrace": "latest",
     "sharp": "latest",
     "svelte": "latest",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1138,10 +1138,10 @@ bl@^4.0.1:
     inherits "^2.0.4"
     readable-stream "^3.4.0"
 
-blurhash@^1.1.3:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/blurhash/-/blurhash-1.1.3.tgz#dc325af7da836d07a0861d830bdd63694382483e"
-  integrity sha512-yUhPJvXexbqbyijCIE/T2NCXcj9iNPhWmOKbPTuR/cm7Q5snXYIfnVnz6m7MWOXxODMz/Cr3UcVkRdHiuDVRDw==
+blurhash@^1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/blurhash/-/blurhash-1.1.4.tgz#a7010ceb3019cd2c9809b17c910ebf6175d29244"
+  integrity sha512-MXIPz6zwYUKayju+Uidf83KhH0vodZfeRl6Ich8Gu+KGl0JgKiFq9LsfqV7cVU5fKD/AotmduZqvOfrGKOfTaA==
 
 bmp-js@^0.1.0:
   version "0.1.0"


### PR DESCRIPTION
We should make sure people are using 1.1.4 for SvelteKit compatibility (https://github.com/matyunya/svelte-image/issues/109)